### PR TITLE
Pin to lower Ubuntu version

### DIFF
--- a/.github/workflows/upload-assets-when-release-published.yml
+++ b/.github/workflows/upload-assets-when-release-published.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   version:
     name: Create version number
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Per advice in GitTools/actions#347

This is to try and fix the GitVersion issue happening right now. Below is the error output:

```
Command: dotnet-gitversion /home/runner/work/tabf/tabf /output json /output buildserver
/opt/hostedtoolcache/GitVersion.Tool/5.2.4/x64/dotnet-gitversion /home/runner/work/tabf/tabf /output json /output buildserver
INFO [07/21/21 19:03:50:68] Working directory: /home/runner/work/tabf/tabf
ERROR [07/21/21 19:03:51:29] An unexpected error occurred:
System.TypeInitializationException: The type initializer for 'LibGit2Sharp.Core.NativeMethods' threw an exception.
 ---> System.DllNotFoundException: Unable to load shared library 'git2-106a5f2' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: libgit2-106a5f2: cannot open shared object file: No such file or directory
   at LibGit2Sharp.Core.NativeMethods.git_libgit2_init()
   at LibGit2Sharp.Core.NativeMethods.InitializeNativeLibrary()
   at LibGit2Sharp.Core.NativeMethods..cctor()
   --- End of inner exception stack trace ---
   at LibGit2Sharp.Core.NativeMethods.git_buf_dispose(GitBuf buf)
   at LibGit2Sharp.Core.Proxy.git_buf_dispose(GitBuf buf)
   at LibGit2Sharp.Core.Handles.GitBuf.Dispose()
   at LibGit2Sharp.Core.Proxy.ConvertPath(Func`2 pathRetriever)
   at LibGit2Sharp.Core.Proxy.git_repository_discover(FilePath start_path)
   at LibGit2Sharp.Repository.Discover(String startingPath)
   at GitVersion.Extensions.ArgumentExtensions.GetProjectRootDirectory(Arguments arguments) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Extensions\ArgumentExtensions.cs:line 34
   at GitVersion.Configuration.ConfigFileLocator.Verify(Arguments arguments) in D:\a\GitVersion\GitVersion\src\GitVersionCore\Configuration\ConfigFileLocator.cs:line 53
   at GitVersion.GitVersionExecutor.HandleNonMainCommand(Arguments arguments, Int32& exitCode) in D:\a\GitVersion\GitVersion\src\GitVersionExe\GitVersionExecutor.cs:line 155
   at GitVersion.GitVersionExecutor.VerifyArgumentsAndRun(Arguments arguments) in D:\a\GitVersion\GitVersion\src\GitVersionExe\GitVersionExecutor.cs:line 58
```