### PR TITLE
Swap the dartfmt and pub get steps

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: subosito/flutter-action@v1
         with:
           channel: 'stable' # or: 'beta', 'dev' or 'master'
-      - run: flutter dartfmt -n --set-exit-if-changed .
       - run: flutter pub get
+      - run: flutter dartfmt -n --set-exit-if-changed .
       - run: flutter analyze
       - run: flutter test


### PR DESCRIPTION
The welcome to flutter banner that shows up crowds out any formatting issues that might be present. Instead, run the flutter command first by getting packages.