### PR TITLE
Remove the need for a composite index

### DIFF
--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -278,10 +278,6 @@ class _HomeScreenState extends State<HomeScreen> with CommandHandler {
   Stream<List<Note>> _createNoteStream(
       BuildContext context, NoteFilter filter) {
     final user = Provider.of<CurrentUser>(context).data;
-    final sinceSignUp = DateTime.now().millisecondsSinceEpoch -
-        (user?.metadata.creationTime?.millisecondsSinceEpoch ?? 0);
-    final useIndexes = sinceSignUp >=
-        _10_min_millis; // since creating indexes takes time, avoid using composite index until later
     final collection = notesCollection(user!.uid);
     final query = filter.noteState == NoteState.unspecified
         ? collection
@@ -291,7 +287,7 @@ class _HomeScreenState extends State<HomeScreen> with CommandHandler {
             .orderBy('state', descending: true) // pinned notes come first
         : collection.where('state', isEqualTo: filter.noteState.index);
 
-    return (useIndexes ? query.orderBy('createdAt', descending: true) : query)
+    return query
         .snapshots()
         .handleError((e) => debugPrint('query notes failed: $e'))
         .map((snapshot) => Note.fromQuery(snapshot));
@@ -309,5 +305,3 @@ class _HomeScreenState extends State<HomeScreen> with CommandHandler {
         : Tuple2(notes!, []);
   }
 }
-
-const _10_min_millis = 600000;

--- a/lib/service/notes_service.dart
+++ b/lib/service/notes_service.dart
@@ -103,12 +103,21 @@ mixin CommandHandler<T extends StatefulWidget> on State<T> {
 /// Add note related methods to [QuerySnapshot].
 extension NoteQuery on QuerySnapshot {
   /// Transforms the query result into a list of notes.
-  List<Note> toNotes() => docs
-      .map((d) => d.toNote())
-      .nonNull
-      // All member aren't null anymore so we can cast to the non-nullable type
-      .map((e) => e as Note)
-      .asList();
+  List<Note> toNotes() {
+    final list = docs
+        .map((d) => d.toNote())
+        .nonNull
+        // All member aren't null anymore so we can cast to the non-nullable type
+        .map((e) => e as Note)
+        .asList();
+    /*
+     * Sort the notes so that the most recent ones appear on top.
+     * This is done here to avoid multiple sortBy calls to the Firestore
+     * which would require the creation of a composite index.
+     */
+    list.sort((a, b) => b.createdAt!.compareTo(a.createdAt!));
+    return list;
+  }
 }
 
 /// Add note related methods to [QuerySnapshot].


### PR DESCRIPTION
Change how notes get sorted so that two `orderBy` calls aren't used. If there are two or more `orderBy` calls in a Firestore query, a composite index would be required (which cannot be created with any kind of automation). Fixes #30.